### PR TITLE
Always use latest version of TextExpander

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,6 +1,6 @@
 class textexpander {
   package { 'textexpander':
     provider   => 'compressed_app',
-    source => 'http://cdn.smilesoftware.com/TextExpander_4.1.zip'
+    source => 'http://dl.smilesoftware.com/com.smileonmymac.textexpander/TextExpander.zip'
   }
 }


### PR DESCRIPTION
I was looking around the TextExpander site and noticed that the download link on the [downloads page](http://smilesoftware.com/TextExpander/download.html) always points to the latest version of TextExpander instead of hardcoding the actual version. 

So I went ahead and updated the source link to always point to the most recent version.
